### PR TITLE
ReadNetCDF.R - Subset of a NetCDF: last time element always omitted.

### DIFF
--- a/R/ReadNetCDF.R
+++ b/R/ReadNetCDF.R
@@ -159,7 +159,7 @@ ReadNetCDF <- function(file, vars = NULL,
 
             if (.is.somedate(sub[1]) | s == "time") {
                 start[[s]] <- which(lubridate::as_datetime(d) %~% min(lubridate::as_datetime(sub)))
-                count[[s]] <- abs(which(lubridate::as_datetime(d) %~% max(lubridate::as_datetime(sub))) - start[[s]])
+                count[[s]] <- abs(which(lubridate::as_datetime(d) %~% max(lubridate::as_datetime(sub))) - start[[s]] + 1)
             } else {
                 start1 <- which(d %~% sub[1])
                 end <- which(d %~% sub[length(sub)])


### PR DESCRIPTION
Last time element in a subset is omitted. Add "+ 1" in the function. Length of any sequence is END - START + 1. Thanks.