### PR TITLE
Removes udunits2 as hard dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,8 +50,8 @@ Suggests:
     reshape2,
     rmarkdown,
     testthat,
-    udunits2,
-    viridis
+    viridis,
+    udunits2
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 - `ReadNetCDF()` suports using `NA` in subset to refer to max or min value. 
 
+- `ReadNetCDF()`'s subset argument supports more complex queries. (see the help 
+section at`?ReadNetCDF()`). 
+
+- `ReadNetCDF()` now has a simple date-time parser that is tried if the udunits2 package
+is not installed. 
 
 # metR 0.4.0 - Cumulonimbus
 

--- a/R/ReadNetCDF.R
+++ b/R/ReadNetCDF.R
@@ -107,7 +107,8 @@ ReadNetCDF <- function(file, vars = NULL,
                        out = c("data.frame", "vector", "array"),
                        subset = NULL, key = FALSE) {
     ncdf4.available <- requireNamespace("ncdf4", quietly = TRUE)
-    udunits2.available <- requireNamespace("udunits2", quietly = TRUE)
+    # udunits2.available <- requireNamespace("udunits2", quietly = TRUE)
+    udunits2.available <- TRUE
     if (!ncdf4.available & !udunits2.available) {
         stop("ReadNetCDF needs packages 'ncdf4' and 'udunits2'. ",
              "Install them with 'install.packages(c(\"ncdf4\", \"udunits2\"))'")
@@ -178,14 +179,14 @@ ReadNetCDF <- function(file, vars = NULL,
     }
     names(dims) <- ids
     has_timedate <- FALSE
-    if ("time" %in% names(dimensions) && ncfile$dim$time$units != "") {
-        has_timedate <- TRUE
-        time <- udunits2::ud.convert(dimensions[["time"]],
-                                     ncfile$dim$time$units,
-                                     "seconds since 1970-01-01 00:00:00")
-        dimensions[["time"]] <- as.character(as.POSIXct(time, tz = "UTC",
-                                                        origin = "1970-01-01 00:00:00"))
-    }
+    # if ("time" %in% names(dimensions) && ncfile$dim$time$units != "") {
+    #     has_timedate <- TRUE
+    #     time <- udunits2::ud.convert(dimensions[["time"]],
+    #                                  ncfile$dim$time$units,
+    #                                  "seconds since 1970-01-01 00:00:00")
+    #     dimensions[["time"]] <- as.character(as.POSIXct(time, tz = "UTC",
+    #                                                     origin = "1970-01-01 00:00:00"))
+    # }
 
     # if (out[1] == "vars") {
     #     r <- list(vars = unname(vars), dimensions = dimensions, dims = dims)

--- a/R/ReadNetCDF.R
+++ b/R/ReadNetCDF.R
@@ -10,6 +10,8 @@
 #' @param out character indicating the type of output desired
 #' @param subset a list of subsetting objects. See below.
 #' @param key if `TRUE`, returns a data.table keyed by the dimensions of the data.
+#' @param ... ignored. Is there for convenience so that a call to [ReadNetCDF()] can
+#' be also valid for [GlanceNetCDF()].
 #'
 #' @section Subsetting:
 #' In the most basic form, `subset` will be a named list whose names must match
@@ -107,22 +109,11 @@ ReadNetCDF <- function(file, vars = NULL,
                        out = c("data.frame", "vector", "array"),
                        subset = NULL, key = FALSE) {
     ncdf4.available <- requireNamespace("ncdf4", quietly = TRUE)
-    # udunits2.available <- requireNamespace("udunits2", quietly = TRUE)
-    udunits2.available <- TRUE
-    if (!ncdf4.available & !udunits2.available) {
-        stop("ReadNetCDF needs packages 'ncdf4' and 'udunits2'. ",
-             "Install them with 'install.packages(c(\"ncdf4\", \"udunits2\"))'")
-    }
-
     if (!ncdf4.available) {
         stop("ReadNetCDF needs package'ncdf4'. ",
              "Install it with 'install.packages(\"ncdf4\")'")
     }
 
-    if (!udunits2.available) {
-        stop("ReadNetCDF needs package 'udunits2'. ",
-             "Install it with 'install.packages(\"udunits2\")'")
-    }
 
     out <- out[1]
     checks <- makeAssertCollection()
@@ -179,14 +170,14 @@ ReadNetCDF <- function(file, vars = NULL,
     }
     names(dims) <- ids
     has_timedate <- FALSE
-    # if ("time" %in% names(dimensions) && ncfile$dim$time$units != "") {
-    #     has_timedate <- TRUE
-    #     time <- udunits2::ud.convert(dimensions[["time"]],
-    #                                  ncfile$dim$time$units,
-    #                                  "seconds since 1970-01-01 00:00:00")
-    #     dimensions[["time"]] <- as.character(as.POSIXct(time, tz = "UTC",
-    #                                                     origin = "1970-01-01 00:00:00"))
-    # }
+    if ("time" %in% names(dimensions) && ncfile$dim$time$units != "") {
+        time <- .parse_time(dimensions[["time"]],
+                            ncfile$dim$time$units)
+        dimensions[["time"]] <- as.character(time)
+        if (.is.somedate(time)) {
+            has_timedate <- TRUE
+        }
+    }
 
     # if (out[1] == "vars") {
     #     r <- list(vars = unname(vars), dimensions = dimensions, dims = dims)
@@ -210,8 +201,8 @@ ReadNetCDF <- function(file, vars = NULL,
             stop('Multiple subsets only supported for `out = "data.frame"')
         }
         reads <- lapply(subset, function(this_subset) {
-                ReadNetCDF(file = file, vars = vars, out = out, key = key, subset = this_subset)
-            })
+            ReadNetCDF(file = file, vars = vars, out = out, key = key, subset = this_subset)
+        })
         return(data.table::rbindlist(reads))
     } else {
         subset <- subset[[1]]
@@ -303,6 +294,34 @@ ReadNetCDF <- function(file, vars = NULL,
     return(nc.df[])
 }
 
+.parse_time <- function(time, units) {
+    if (!requireNamespace("udunits2", quietly = TRUE)) {
+        message("Time dimension found and package udunits2 is not installed. Trying to parse.")
+        fail <- paste0("Time parsing failed. Returing raw values in ", units, ".\n",
+                       "Install udunits2 with `install_packages(\"udunits2\")` to parse it automatically.")
+
+        units <- trimws(strsplit(units, "since")[[1]])
+
+        period_fun <- try(match.fun(units[1]), silent = TRUE)
+        if (is.error(period_fun)) {
+            warning(fail)
+            return(time)
+        }
+
+        time_try <- try(as.POSIXct(units[2],  tz = "UTC", origin = "1970-01-01 00:00:00") +
+                            period_fun(time),
+                        silent = TRUE)
+        if (is.error(time_try)) {
+            warning(fail)
+            return(time)
+        }
+        return(time_try)
+    }
+
+    time <- udunits2::ud.convert(time, units,
+                                 "seconds since 1970-01-01 00:00:00")
+    as.POSIXct(time, tz = "UTC", origin = "1970-01-01 00:00:00")
+}
 
 .expand_chunks <- function(subset) {
     if (is.null(subset)) {
@@ -362,7 +381,7 @@ ReadNetCDF <- function(file, vars = NULL,
 #' @rdname ReadNetCDF
 #'
 #' @export
-GlanceNetCDF <- function(file) {
+GlanceNetCDF <- function(file, ...) {
     ReadNetCDF(file, out = "vars")
 }
 
@@ -397,11 +416,13 @@ print.ncvar4 <- function(x, ...) {
 print.ncdim4 <- function(x, ...) {
     # cat("$", dim$name, "\n", sep = "")
     if (x$name == "time" & x$units != "") {
-        time <- udunits2::ud.convert(x$vals,
-                                     x$units,
-                                     "seconds since 1970-01-01 00:00:00")
-        vals <- as.POSIXct(time, tz = "UTC", origin = "1970-01-01 00:00:00")
-        units <- ""
+        vals <- suppressMessages(suppressWarnings(.parse_time(x$vals, x$units)))
+
+        if (.is.somedate(vals)) {
+            units <- ""
+        }
+
+
     } else {
         vals <- x$vals
         units <- x$units

--- a/man/ReadNetCDF.Rd
+++ b/man/ReadNetCDF.Rd
@@ -8,7 +8,7 @@
 ReadNetCDF(file, vars = NULL, out = c("data.frame", "vector", "array"),
   subset = NULL, key = FALSE)
 
-GlanceNetCDF(file)
+GlanceNetCDF(file, ...)
 }
 \arguments{
 \item{file}{file to read from.}
@@ -21,6 +21,9 @@ GlanceNetCDF(file)
 \item{subset}{a list of subsetting objects. See below.}
 
 \item{key}{if \code{TRUE}, returns a data.table keyed by the dimensions of the data.}
+
+\item{...}{ignored. Is there for convenience so that a call to \code{\link[=ReadNetCDF]{ReadNetCDF()}} can
+be also valid for \code{\link[=GlanceNetCDF]{GlanceNetCDF()}}.}
 }
 \value{
 The return format is specified by \code{out}. It can be a data table in which each

--- a/man/scale_divergent.Rd
+++ b/man/scale_divergent.Rd
@@ -17,11 +17,10 @@ scale_fill_divergent(..., low = scales::muted("blue"), mid = "white",
 \arguments{
 \item{...}{Arguments passed on to \code{continuous_scale}
 \describe{
-  \item{scale_name}{The name of the scale that should be used for error messages
-associated with this scale.}
+  \item{scale_name}{The name of the scale}
   \item{palette}{A palette function that when called with a numeric vector with
-values between 0 and 1 returns the corresponding output values
-(e.g., \code{\link[scales:area_pal]{scales::area_pal()}}).}
+values between 0 and 1 returns the corresponding values in the range the
+scale maps to.}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be
@@ -30,10 +29,10 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+transformation object
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
-as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scales::extended_breaks()}})
+as output
 }}
   \item{minor_breaks}{One of:
 \itemize{
@@ -59,44 +58,32 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-Note that setting limits on positional scales will \strong{remove} data outside of the limits.
-If the purpose is to zoom, use the limit argument in the coordinate system
-(see \code{\link[=coord_cartesian]{coord_cartesian()}}).
 }}
-  \item{rescaler}{A function used to scale the input values to the
-range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
-diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},
-\code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
-scales, which ways use \code{\link[scales:rescale]{scales::rescale()}}.}
-  \item{oob}{One of:
-\itemize{
-\item Function that handles limits outside of the scale limits
-(out of bounds).
-\item The default (\code{\link[scales:censor]{scales::censor()}}) replaces out of
-bounds values with \code{NA}.
-\item \code{\link[scales:squish]{scales::squish()}} for squishing out of bounds values into range.
-\item \code{\link[scales:squish_infinite]{scales::squish_infinite()}} for squishing infitite values into range.
-}}
-  \item{trans}{For continuous scales, the name of a transformation object
-or the object itself. Built-in transformations include "asn", "atanh",
+  \item{rescaler}{Used by diverging and n colour gradients
+(i.e. \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}}, \code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}).
+A function used to scale the input values to the range [0, 1].}
+  \item{oob}{Function that handles limits outside of the scale limits
+(out of bounds). The default replaces out of bounds values with \code{NA}.}
+  \item{trans}{Either the name of a transformation object, or the
+object itself. Built-in transformations include "asn", "atanh",
 "boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
 "logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
 "reverse", "sqrt" and "time".
 
 A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
-are defined in the scales package, and are called \code{<name>_trans} (e.g.,
-\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}). You can create your own
+are defined in the scales package, and are called \code{name_trans}, e.g.
+\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}. You can create your own
 transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
-  \item{expand}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
+  \item{position}{The position of the axis. "left" or "right" for vertical
+scales, "top" or "bottom" for horizontal scales}
+  \item{super}{The super class to use for the constructed scale}
+  \item{expand}{Vector of range expansion constants used to add some
+padding around the data, to ensure that they are placed some distance
+away from the axes. Use the convenience function \code{\link[=expand_scale]{expand_scale()}}
 to generate the values for the \code{expand} argument. The defaults are to
 expand the scale by 5\% on each side for continuous variables, and by
 0.6 units on each side for discrete variables.}
-  \item{position}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
-  \item{super}{The super class to use for the constructed scale}
 }}
 
 \item{low}{Colours for low and high ends of the gradient.}

--- a/man/scale_longitude.Rd
+++ b/man/scale_longitude.Rd
@@ -41,15 +41,15 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+transformation object
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
-as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scales::extended_breaks()}})
+as output
 }}
 
-\item{expand}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
+\item{expand}{Vector of range expansion constants used to add some
+padding around the data, to ensure that they are placed some distance
+away from the axes. Use the convenience function \code{\link[=expand_scale]{expand_scale()}}
 to generate the values for the \code{expand} argument. The defaults are to
 expand the scale by 5\% on each side for continuous variables, and by
 0.6 units on each side for discrete variables.}
@@ -64,16 +64,16 @@ transformation object
 as output
 }}
 
-\item{trans}{For continuous scales, the name of a transformation object
-or the object itself. Built-in transformations include "asn", "atanh",
+\item{trans}{Either the name of a transformation object, or the
+object itself. Built-in transformations include "asn", "atanh",
 "boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
 "logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
 "reverse", "sqrt" and "time".
 
 A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
-are defined in the scales package, and are called \code{<name>_trans} (e.g.,
-\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}). You can create your own
+are defined in the scales package, and are called \code{name_trans}, e.g.
+\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}. You can create your own
 transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
 
 \item{...}{Other arguments passed on to \code{scale_(x|y)_continuous()}}


### PR DESCRIPTION
ReadNetCDF() now can read files with no udunits2 package installed. If a date time dimension is found, first it tries to parse it and if it fails, it returns the raw values with a warning. 